### PR TITLE
FIXes WARNing about registering already registered CVar

### DIFF
--- a/gdx-test/src/main/java/de/hochschuletrier/gdw/ws1516/game/Game.java
+++ b/gdx-test/src/main/java/de/hochschuletrier/gdw/ws1516/game/Game.java
@@ -67,6 +67,7 @@ public class Game extends InputAdapter {
     }
 
     public void init(AssetManagerX assetManager) {
+        Main.getInstance().console.unregister(physixDebug); // if already registered by previous initialisation
         Main.getInstance().console.register(physixDebug);
         physixDebug.addListener((CVar) -> physixDebugRenderSystem.setProcessing(physixDebug.get()));
 


### PR DESCRIPTION
Behebt ein WARN in der Beispielanwendung. Nicht unbedingt notwendig wollte einfach ein bisschen mit der CodeBase rumspielen.
